### PR TITLE
feat: Add Vercel configuration and enhance Vite build settings

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,19 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,19 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  build: {
+    outDir: 'dist',
+    sourcemap: false,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom'],
+        },
+      },
+    },
+  },
+  server: {
+    port: 3000,
+    host: true,
+  },
 })


### PR DESCRIPTION
- Introduced `vercel.json` for routing and caching headers configuration.
- Updated `vite.config.ts` to specify output directory, disable sourcemaps, and define manual chunks for vendor libraries.
- Configured server settings to run on port 3000 with host enabled.